### PR TITLE
prevent pruning subowners of multi-level nested subcomponents

### DIFF
--- a/src/ahp_graph/DeviceGraph.py
+++ b/src/ahp_graph/DeviceGraph.py
@@ -249,8 +249,17 @@ class DeviceGraph:
             if d0.partition[0] == rank or d1.partition[0] == rank:
                 devices_to_keep.add(d0)
                 devices_to_keep.add(d1)
-                devices_to_keep.add(d0.subOwner)
-                devices_to_keep.add(d1.subOwner)
+
+                d0_so = d0.subOwner
+                while d0_so:
+                    devices_to_keep.add(d0_so)
+                    d0_so=d0_so.subOwner
+            
+                d1_so = d1.subOwner
+                while d1_so:
+                    devices_to_keep.add(d1_so)
+                    d1_so=d1_so.subOwner
+
                 if d0.subs:
                     for s0 in d0.subs:
                         devices_to_keep.add(s0)


### PR DESCRIPTION
This will now appropriately add the relevant parent components, when the graph contains more than one layer of sub-components. 

This was especially problematic in multi rank mpi runs, where the a component with nested sub-components existed on one partition, and only the bottom most sub-component linked to a component on another partition. On the non-assigned partitions, the parent component was never added as a "device to keep". This prevented the bottom most subcomponent from being present in the built graphs.