### PR TITLE
Change `remove` to `discard` to allow self-links

### DIFF
--- a/src/ahp_graph/DeviceGraph.py
+++ b/src/ahp_graph/DeviceGraph.py
@@ -276,8 +276,8 @@ class DeviceGraph:
             del self.links[(p0, p1)]
             p0.link = None
             p1.link = None
-            self.ports.remove(p0)
-            self.ports.remove(p1)
+            self.ports.discard(p0)
+            self.ports.discard(p1)
 
         #
         # Remove all devices we do not need to keep
@@ -382,8 +382,8 @@ class DeviceGraph:
                             del self.links[(p0, p1)]
                             p0.link = None
                             p1.link = None
-                            self.ports.remove(p0)
-                            self.ports.remove(p1)
+                            self.ports.discard(p0)
+                            self.ports.discard(p1)
 
                     for device in self.expand_new_devices:
                         del self.devices[device.name]


### PR DESCRIPTION
This changes a few set `remove`s to `discard`s to allow topologies with self-links. Our PHOLD benchmark relies on self-loops existing, and AHP was throwing errors since the self-links connect via the same port. 

Sample correctness test below comparing AHP PHOLD with added `discard`s to OG PHOLD that does not use AHP. Both the OG PHOLD and AHP PHOLD can be found [here](https://github.com/hpc-ai-adv-dev/sst-benchmarks/tree/main/phold) as `phold_dist.py` and `phold_dist_ahp.py`, respectively. 


i | j | OG PHOLD | AHP PHOLD
-- | -- | -- | --
0 | 0 | 72 | 72
0 | 1 | 100 | 100
0 | 2 | 113 | 113
0 | 3 | 81 | 81
1 | 0 | 134 | 134
1 | 1 | 168 | 168
1 | 2 | 147 | 147
1 | 3 | 141 | 141
2 | 0 | 108 | 108
2 | 1 | 179 | 179
2 | 2 | 191 | 191
2 | 3 | 126 | 126
3 | 0 | 78 | 78
3 | 1 | 117 | 117
3 | 2 | 134 | 134
3 | 3 | 111 | 111