### PR TITLE
Write Model Updates

### DIFF
--- a/src/ahp_graph/SSTGraph.py
+++ b/src/ahp_graph/SSTGraph.py
@@ -262,10 +262,7 @@ class SSTGraph(DeviceGraph):
                 if d1.library is None:
                     raise RuntimeError(f"No library: {d1.name}")
                 
-                # TODO: Extra type is causing SST 15.1+ duplication error.
-                # d1.attr.update(type=d1.type, model=d1.model)
-                d1.attr.update(model=d1.model)
-                
+                d1.attr.update(type=d1.type, model=d1.model)
                 item = {
                     "slot_name" : n1,
                     "type" : d1.library,
@@ -288,11 +285,7 @@ class SSTGraph(DeviceGraph):
         components = list()
         for d0 in self.devices.values():
             if d0.subOwner is None and d0.library is not None:
-                
-                # TODO: Extra type is causing SST 15.1+ duplication error.
-                # d0.attr.update(type=d0.type, model=d0.model)
-                d0.attr.update(model=d0.model)
-                
+                d0.attr.update(type=d0.type, model=d0.model)
                 component = {
                     "name" : d0.name,
                     "type" : d0.library,
@@ -321,8 +314,6 @@ class SSTGraph(DeviceGraph):
         #
         links = list()
         for ((p0,p1),t) in self.links.items():
-            #assert p0.device.library is not None
-            #assert p1.device.library is not None
             if p0.device.library is None:
                 raise RuntimeError(f"No SST library: {p0.device.name}")
             if p1.device.library is None:

--- a/src/ahp_graph/SSTGraph.py
+++ b/src/ahp_graph/SSTGraph.py
@@ -98,12 +98,14 @@ class SSTGraph(DeviceGraph):
             self.__write_model(
                 f"{output}/{filename}",
                 nranks,
+                rank,
                 program_options)
         else:
             (base, ext) = os.path.splitext(f"{output}/{filename}")
             self.__write_model(
                 base + str(rank) + ext,
                 nranks,
+                rank,
                 program_options)
 
     @staticmethod
@@ -213,6 +215,7 @@ class SSTGraph(DeviceGraph):
     def __write_model(self,
                       filename: str,
                       nranks: int,
+                      rank: int,
                       program_options: dict = None) -> None:
         """
         Write this DeviceGraph out as JSON.
@@ -228,10 +231,10 @@ class SSTGraph(DeviceGraph):
             model["program_options"] = dict(program_options)
 
         #
-        # If running in parallel, then set up the SST SELF partitioner.
+        # If running in parallel, then set up the SST LINEAR partitioner.
         #
         if nranks > 1:
-            model["program_options"]["partitioner"] = "sst.self"
+            model["program_options"]["partitioner"] = "sst.linear"
 
         #
         # Set up global parameters.
@@ -251,13 +254,16 @@ class SSTGraph(DeviceGraph):
                 if d1.library is None:
                     raise RuntimeError(f"No library: {d1.name}")
                 
-                d1.attr.update(type=d1.type, model=d1.model)
                 item = {
                     "slot_name" : n1,
                     "type" : d1.library,
                     "slot_number" : s1,
-                    "params" : self.__encode(d1.attr, True),
-                    "params_global_sets" : global_set,
+                    # omit internal metadata like type/model from params
+                    "params" : self.__encode({
+                        k: v for (k, v) in d1.attr.items()
+                        if k not in ("type", "model")
+                    }, True),
+                    # "params_global_sets" : global_set,
                 }
                 if d1.subs:
                     item["subcomponents"] = recurseSubcomponents(d1)
@@ -271,12 +277,19 @@ class SSTGraph(DeviceGraph):
         components = list()
         for d0 in self.devices.values():
             if d0.subOwner is None and d0.library is not None:
-                d0.attr.update(type=d0.type, model=d0.model)
+                # In multi-rank output, only emit components local to this rank
+                if nranks > 1:
+                    if d0.partition is None or d0.partition[0] != rank:
+                        continue
                 component = {
                     "name" : d0.name,
                     "type" : d0.library,
-                    "params" : self.__encode(d0.attr, True),
-                    "params_global_sets" : global_set,
+                    # omit internal metadata like type/model from params
+                    "params" : self.__encode({
+                        k: v for (k, v) in d0.attr.items()
+                        if k not in ("type", "model")
+                    }, True),
+                    # "params_global_sets" : global_set,
                 }
                 if d0.partition is not None:
                     component["partition"] = {
@@ -309,19 +322,57 @@ class SSTGraph(DeviceGraph):
                 name = f'{p0}__{t}__{p1}'
             else:
                 name = f'{p1}__{t}__{p0}'
-            links.append({
-                "name" : name,
-                "left" : {
-                    "component" : p0.device.name,
-                    "port" : p0.get_name(),
-                    "latency" : latency
-                },
-                "right" : {
-                    "component" : p1.device.name,
-                    "port" : p1.get_name(),
-                    "latency" : latency
-                },
-            })
+
+            d0 = p0.device
+            d1 = p1.device
+            r0, t0 = (d0.partition or (0, None))
+            r1, t1 = (d1.partition or (0, None))
+            t0 = 0 if t0 is None else t0
+            t1 = 0 if t1 is None else t1
+
+            # Determine if link is inter-rank relative to this file's rank
+            is_nonlocal = nranks > 1 and r0 != r1
+
+            if is_nonlocal:
+                # Ensure left side is the local endpoint for this rank
+                if r0 == rank:
+                    left = {"component": d0.name, "port": p0.get_name(), "latency": latency}
+                    right = {"rank": r1, "thread": t1}
+                elif r1 == rank:
+                    left = {"component": d1.name, "port": p1.get_name(), "latency": latency}
+                    right = {"rank": r0, "thread": t0}
+                else:
+                    # Neither endpoint is local to this rank; skip emitting
+                    # (should not occur after prune, but guard just in case)
+                    continue
+
+                links.append({
+                    "name": name,
+                    "noCut": False,
+                    "nonlocal": True,
+                    "left": left,
+                    "right": right,
+                })
+            else:
+                # Local link (same-rank or single-rank output): keep both endpoints
+                # If multi-rank, only keep links where both endpoints are on this rank
+                if nranks > 1 and not (r0 == rank and r1 == rank):
+                    continue
+                links.append({
+                    "name": name,
+                    "noCut": False,
+                    "nonlocal": False,
+                    "left": {
+                        "component": d0.name,
+                        "port": p0.get_name(),
+                        "latency": latency,
+                    },
+                    "right": {
+                        "component": d1.name,
+                        "port": p1.get_name(),
+                        "latency": latency,
+                    },
+                })
 
         model["links"] = links
 

--- a/src/ahp_graph/SSTGraph.py
+++ b/src/ahp_graph/SSTGraph.py
@@ -172,7 +172,10 @@ class SSTGraph(DeviceGraph):
                     c1 = comp.setSubComponent(n1, d1.library)
                 else:
                     c1 = comp.setSubComponent(n1, d1.library, s1)
-                d1.attr.update(type=d1.type, model=d1.model)
+                if d1.type is not None:
+                    d1.attr['type'] = d1.type
+                if d1.model is not None:
+                    d1.attr['model'] = d1.model
                 c1.addParams(self.__encode(d1.attr))
                 n2c[d1.name] = c1
                 for key in global_params:
@@ -185,7 +188,10 @@ class SSTGraph(DeviceGraph):
         for d0 in self.devices.values():
             if d0.subOwner is None and d0.library is not None:
                 c0 = sst.Component(d0.name, d0.library)
-                d0.attr.update(type=d0.type, model=d0.model)
+                if d0.type is not None:
+                    d0.attr['type'] = d0.type
+                if d0.model is not None:
+                    d0.attr['model'] = d0.model
                 c0.addParams(self.__encode(d0.attr))
                 # Set the component partition if we are self-partitioning
                 if self_partition:
@@ -254,15 +260,17 @@ class SSTGraph(DeviceGraph):
                 if d1.library is None:
                     raise RuntimeError(f"No library: {d1.name}")
                 
+                params_dict = {k: v for (k, v) in d1.attr.items()}
+                if d1.type is not None:
+                    params_dict['type'] = d1.type
+                if d1.model is not None:
+                    params_dict['model'] = d1.model
+                
                 item = {
                     "slot_name" : n1,
                     "type" : d1.library,
                     "slot_number" : s1,
-                    # omit internal metadata like type/model from params
-                    "params" : self.__encode({
-                        k: v for (k, v) in d1.attr.items()
-                        if k not in ("type", "model")
-                    }, True),
+                    "params" : self.__encode(params_dict, True),
                     # "params_global_sets" : global_set,
                 }
                 if d1.subs:
@@ -281,14 +289,16 @@ class SSTGraph(DeviceGraph):
                 if nranks > 1:
                     if d0.partition is None or d0.partition[0] != rank:
                         continue
+                params_dict = {k: v for (k, v) in d0.attr.items()}
+                if d0.type is not None:
+                    params_dict['type'] = d0.type
+                if d0.model is not None:
+                    params_dict['model'] = d0.model
+                
                 component = {
                     "name" : d0.name,
                     "type" : d0.library,
-                    # omit internal metadata like type/model from params
-                    "params" : self.__encode({
-                        k: v for (k, v) in d0.attr.items()
-                        if k not in ("type", "model")
-                    }, True),
+                    "params" : self.__encode(params_dict, True),
                     # "params_global_sets" : global_set,
                 }
                 if d0.partition is not None:

--- a/src/ahp_graph/SSTGraph.py
+++ b/src/ahp_graph/SSTGraph.py
@@ -172,10 +172,7 @@ class SSTGraph(DeviceGraph):
                     c1 = comp.setSubComponent(n1, d1.library)
                 else:
                     c1 = comp.setSubComponent(n1, d1.library, s1)
-                if d1.type is not None:
-                    d1.attr['type'] = d1.type
-                if d1.model is not None:
-                    d1.attr['model'] = d1.model
+                d1.attr.update(type=d1.type, model=d1.model)
                 c1.addParams(self.__encode(d1.attr))
                 n2c[d1.name] = c1
                 for key in global_params:
@@ -188,10 +185,7 @@ class SSTGraph(DeviceGraph):
         for d0 in self.devices.values():
             if d0.subOwner is None and d0.library is not None:
                 c0 = sst.Component(d0.name, d0.library)
-                if d0.type is not None:
-                    d0.attr['type'] = d0.type
-                if d0.model is not None:
-                    d0.attr['model'] = d0.model
+                d0.attr.update(type=d0.type, model=d0.model)
                 c0.addParams(self.__encode(d0.attr))
                 # Set the component partition if we are self-partitioning
                 if self_partition:

--- a/src/ahp_graph/SSTGraph.py
+++ b/src/ahp_graph/SSTGraph.py
@@ -245,11 +245,13 @@ class SSTGraph(DeviceGraph):
         #
         # Set up global parameters.
         #
-        global_params = self.__encode(self.attr, True)
-        model["global_params"] = dict()
-        for (key, val) in global_params.items():
-            model["global_params"][key] = dict({key: val})
-        global_set = list(global_params.keys())
+        # TODO: Revert if needed, but is causing parsing issue with
+        #       SST 15.1+
+        # global_params = self.__encode(self.attr, True)
+        # model["global_params"] = dict()
+        # for (key, val) in global_params.items():
+        #     model["global_params"][key] = dict({key: val})
+        # global_set = list(global_params.keys())
 
         def recurseSubcomponents(dev: Device) -> list:
             """Add subcomponents to the Device."""
@@ -260,17 +262,18 @@ class SSTGraph(DeviceGraph):
                 if d1.library is None:
                     raise RuntimeError(f"No library: {d1.name}")
                 
-                params_dict = {k: v for (k, v) in d1.attr.items()}
-                if d1.type is not None:
-                    params_dict['type'] = d1.type
-                if d1.model is not None:
-                    params_dict['model'] = d1.model
+                # TODO: Extra type is causing SST 15.1+ duplication error.
+                # d1.attr.update(type=d1.type, model=d1.model)
+                d1.attr.update(model=d1.model)
                 
                 item = {
                     "slot_name" : n1,
                     "type" : d1.library,
                     "slot_number" : s1,
-                    "params" : self.__encode(params_dict, True),
+                    "params" : self.__encode(d1.attr, True),
+                    
+                    # TODO: Revert if needed, but is causing parsing issue with
+                    #       SST 15.1+
                     # "params_global_sets" : global_set,
                 }
                 if d1.subs:
@@ -285,20 +288,18 @@ class SSTGraph(DeviceGraph):
         components = list()
         for d0 in self.devices.values():
             if d0.subOwner is None and d0.library is not None:
-                # In multi-rank output, only emit components local to this rank
-                if nranks > 1:
-                    if d0.partition is None or d0.partition[0] != rank:
-                        continue
-                params_dict = {k: v for (k, v) in d0.attr.items()}
-                if d0.type is not None:
-                    params_dict['type'] = d0.type
-                if d0.model is not None:
-                    params_dict['model'] = d0.model
+                
+                # TODO: Extra type is causing SST 15.1+ duplication error.
+                # d0.attr.update(type=d0.type, model=d0.model)
+                d0.attr.update(model=d0.model)
                 
                 component = {
                     "name" : d0.name,
                     "type" : d0.library,
-                    "params" : self.__encode(params_dict, True),
+                    "params" : self.__encode(d0.attr, True),
+                    
+                    # TODO: Revert if needed, but is causing parsing issue with
+                    #       SST 15.1+
                     # "params_global_sets" : global_set,
                 }
                 if d0.partition is not None:
@@ -352,8 +353,8 @@ class SSTGraph(DeviceGraph):
                     left = {"component": d1.name, "port": p1.get_name(), "latency": latency}
                     right = {"rank": r0, "thread": t0}
                 else:
-                    # Neither endpoint is local to this rank; skip emitting
-                    # (should not occur after prune, but guard just in case)
+                    # Neither endpoint is local to this rank, skip emitting
+                    # This shouldn't really happen, but added as a safeguard.
                     continue
 
                 links.append({


### PR DESCRIPTION
This PR makes changes to AHP's `__write_model` function to align it with SST's 15.1+ expected JSON parser. The two major changes this PR tackles follow:
1. For nonlocal links, it specifically makes the "left" component the local one, and formats the "right" format as expected. 
2. Comments out and adds TODOs to lines of code causing duplication and parsing errors with SST 15.1+