### PR TITLE
do not append empty model name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 dist
 *.egg-info
 sstcore*.tar.gz
+.venv/

--- a/src/ahp_graph/Device.py
+++ b/src/ahp_graph/Device.py
@@ -278,7 +278,7 @@ class Device:
 
     def get_category(self) -> str:
         """Return the category for this Device (type, model)."""
-        if self.model is not None:
+        if self.model is not None and self.model.strip():
             return f"{self.type}_{self.model}"
         return self.type
 

--- a/tests/Devices.py
+++ b/tests/Devices.py
@@ -1,5 +1,7 @@
 """Collection of ahp_graph Devices for testing."""
 
+from typing import Any
+
 from ahp_graph.Device import *
 from ahp_graph.DeviceGraph import *
 
@@ -104,3 +106,8 @@ class AttributeTestDevice(Device):
     def __init__(self, attr: dict[str, Any], name: str = '') -> None:
         """Test Device with attributes."""
         super().__init__(f'{self.__class__.__name__}{name}', attr=attr)
+
+
+class AssemblyTestDevice(Device):
+    def expand(self, grpah: DeviceGraph) -> None:
+        pass

--- a/tests/test_Device.py
+++ b/tests/test_Device.py
@@ -128,3 +128,18 @@ def test_submodule() -> None:
     assert pop[0] == ltd1, 'subs'
     assert pop[1] == 'slotName', 'slotName'
     assert pop[2] is None, 'slotIndex'
+
+
+def test_empty_model() -> None:
+    """Test that empty model name is not included in category (and not suffixed with '_')"""
+    device = AssemblyTestDevice("Name", "model")
+    assert device.get_category() == "AssemblyTestDevice_model"
+
+    device = AssemblyTestDevice("Name", " ")
+    assert device.get_category() == "AssemblyTestDevice"
+
+    device = AssemblyTestDevice("Name", "")
+    assert device.get_category() == "AssemblyTestDevice"
+
+    device = AssemblyTestDevice("Name")
+    assert device.get_category() == "AssemblyTestDevice"


### PR DESCRIPTION
When we made devices with an empty model, we would get `DeviceName_` for `get_category()` instead of just `DeviceName`. This PR prevents the code from trying to append an empty model name (and therefore an extra `_`), including empty strings or strings with only whitespace. Previously it only checked for None.

I added a test case for this change, and while running all tests found that some are failing for me locally. The new test I added passed locally. I have not tried addressing the other failures.